### PR TITLE
Bug: use className instead of class

### DIFF
--- a/src/components/BreweryList.js
+++ b/src/components/BreweryList.js
@@ -41,7 +41,7 @@ export default class BreweryList extends Component {
             <form className="form-inline my-2 my-lg-0">
               <button
                 type="button"
-                class="btn btn-outline-info"
+                className="btn btn-outline-info"
                 onClick={() => this.onClick()}
               >
                 Back to Search


### PR DESCRIPTION
switch traditional 'class' property of the button element with 'className'.