### PR TITLE
Fix Constant Polling + Misc Changes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,16 +3,20 @@ import "./App.css";
 import BreweryList from "./components/BreweryList";
 import BrewerySearch from "./components/BrewerySearch";
 
+const PAGE_HOME = "home";
+const PAGE_RESULTS = "search_results";
+
 class App extends Component {
   state = {
     items: [],
     isLoaded: false,
     url: "https://api.openbrewerydb.org/breweries",
-    pageIndex: 0
+    page: PAGE_HOME 
   };
 
   async fetchBreweryData() {
     try {
+      this.setState({ isLoaded: false });
       const data = await fetch(this.state.url);
       const jsonData = await data.json();
       const cleanData = this.filterResults(jsonData);
@@ -33,23 +37,24 @@ class App extends Component {
     );
   };
 
-  async handleSearch(searchTerm) {
-    await this.setState({
-      url: `https://api.openbrewerydb.org/breweries?by_city=${searchTerm}`,
-      pageIndex: 1
-    });
-    console.log("App " + searchTerm);
-    console.log("App state: " + this.state.url);
-  }
-
-  backToSearch() {
+  handleSearch = searchTerm => {
     this.setState({
-      pageIndex: 0
+      url: `https://api.openbrewerydb.org/breweries?by_city=${searchTerm}`,
+      page: PAGE_RESULTS
     });
   }
 
-  componentDidUpdate() {
-    this.fetchBreweryData();
+  backToSearch = () => {
+    this.setState({
+      page: PAGE_HOME
+    });
+  }
+
+  componentDidUpdate(previousProps, previousState) {
+    const searchChanged = this.state.url !== previousState.url;
+    if (searchChanged) {
+      this.fetchBreweryData();
+    }
   }
 
   componentDidMount() {
@@ -57,15 +62,15 @@ class App extends Component {
   }
 
   whatToDisplay = page => {
-    if (page === 1) {
+    if (page === PAGE_RESULTS) {
       return (
         <BreweryList
           brewery={this.state.items}
-          backToSearch={() => this.backToSearch()}
+          backToSearch={this.backToSearch}
         />
       );
-    } else if (page === 0) {
-      return <BrewerySearch handleSearch={this.handleSearch.bind(this)} />;
+    } else if (page === PAGE_HOME) {
+      return <BrewerySearch handleSearch={this.handleSearch} />;
     }
   };
 
@@ -76,7 +81,7 @@ class App extends Component {
     } else {
       return (
         <React.Fragment>
-          {this.whatToDisplay(this.state.pageIndex)}
+          {this.whatToDisplay(this.state.page)}
         </React.Fragment>
       );
     }

--- a/src/components/Brewery.js
+++ b/src/components/Brewery.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 
 export default class Brewery extends Component {
-  displayWebsiteUrl = () => {
+  displayWebsiteUrl() {
     if (this.props.item.website_url === "") {
       return;
     } else {

--- a/src/components/BrewerySearch.js
+++ b/src/components/BrewerySearch.js
@@ -6,11 +6,11 @@ export default class BrewerySearch extends Component {
     search: "Boston"
   };
 
-  updateSearch(event) {
+  updateSearch = event => {
     this.setState({ search: event.target.value });
   }
 
-  onSearchClick() {
+  onSearchClick = () => {
     this.props.handleSearch(this.state.search);
     console.log(this.state.search);
   }
@@ -52,11 +52,11 @@ export default class BrewerySearch extends Component {
                   className="form-control"
                   type="text"
                   placeholder="Enter city name..."
-                  onChange={this.updateSearch.bind(this)}
+                  onChange={this.updateSearch}
                 />
                 <button
                   className="btn btn-primary mx-2"
-                  onClick={() => this.onSearchClick()}
+                  onClick={this.onSearchClick}
                 >
                   Search
                 </button>


### PR DESCRIPTION
### Changes
- Prevent constant polling of api endpoint due to calls to setState triggering refresh in `componentDidUpdate`
- Set `isLoaded` to false before starting a new API call. This shows the correct loading state while the api call is being made.
- Update use of bound class variables to remove the need to `bind` during the render cycle.
- Update use of `pageIndex` to just `page` with constants to help make it clear they are different pages and not paginated results.

Original Issue: 
![polling](https://user-images.githubusercontent.com/2012909/53539759-79a95c00-3ad8-11e9-980b-1da4ff655b39.gif)
