### PR TITLE
Fixed searchByParam in App.js state to default to "city" when returning from search results

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -41,6 +41,7 @@ class App extends Component {
 
   backToSearch = () => {
     this.setState({
+      searchByParam: "city",
       page: PAGE_HOME
     });
   };


### PR DESCRIPTION
Set searchByParam to always be city when switching from search result page back to search page.
