### PR TITLE
Added react tooltip dependency, added tooltips to radio buttons. issue #32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3386,6 +3386,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
     "clean-css": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
@@ -14360,6 +14365,15 @@
             "path-parse": "^1.0.5"
           }
         }
+      }
+    },
+    "react-tooltip": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.9.2.tgz",
+      "integrity": "sha512-uoOXt/LVX9JhSYjAa3F2qSJuaTwod1fW2PWJGWGZ7Sfm6M8/JGWvGY1LsR51g8LYteVcSbDFuHfuB3rmNFACRw==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.0"
       }
     },
     "react-typed": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-scripts": "2.1.3",
+    "react-tooltip": "^3.9.2",
     "react-typed": "^1.1.0"
   },
   "scripts": {

--- a/src/App.js
+++ b/src/App.js
@@ -96,7 +96,7 @@ class App extends Component {
 
   render() {
     const { isLoaded, page } = this.state;
-    if (this.state.page == PAGE_RESULTS && !isLoaded) {
+    if (this.state.page === PAGE_RESULTS && !isLoaded) {
       return <div>Loading...</div>;
     } else {
       return <React.Fragment>{this.whatToDisplay(page)}</React.Fragment>;

--- a/src/components/BrewerySearch.js
+++ b/src/components/BrewerySearch.js
@@ -6,20 +6,20 @@ export default class BrewerySearch extends Component {
   state = {
     search: "",
     searchBy: "city"
-  }
+  };
 
   updateSearch = event => {
     this.setState({ search: event.target.value });
-  }
+  };
 
   onSearchClick = () => {
     this.props.handleSearch(this.state.search);
-  }
+  };
 
   onSearchChange = event => {
     this.setState({ searchBy: event.target.value });
     this.props.searchBy(event.target.value);
-  }
+  };
 
   render() {
     return (
@@ -30,10 +30,10 @@ export default class BrewerySearch extends Component {
               <h1 className="Quicksand-Text Glow">Brewery Finder</h1>
               <Typed
                 strings={[
-                  'Find a brewery in your hometown',
-                  'Find your new hangout',
-                  'Find your new favorite beer',
-                  'Find the answer to your problems'
+                  "Find a brewery in your hometown",
+                  "Find your new hangout",
+                  "Find your new favorite beer",
+                  "Find the answer to your problems"
                 ]}
                 typeSpeed={70}
                 startDelay={1200}
@@ -42,7 +42,7 @@ export default class BrewerySearch extends Component {
                 loop={true}
                 loopCount={30}
                 showCursor={true}
-                className={'h4'}
+                className={"h4"}
               />
             </div>
           </div>
@@ -71,37 +71,44 @@ export default class BrewerySearch extends Component {
                 searchBy={this.state.searchBy}
                 handleSearchChange={this.onSearchChange}
                 identifier="cityRadio"
+                tooltip="Search by city"
               />
               <RadioButtonContainer
                 val="state"
                 searchBy={this.state.searchBy}
                 handleSearchChange={this.onSearchChange}
                 identifier="stateRadio"
+                tooltip="Search by state"
               />
               <RadioButtonContainer
                 val="name"
                 searchBy={this.state.searchBy}
                 handleSearchChange={this.onSearchChange}
                 identifier="nameRadio"
+                tooltip="Search by brewery name"
               />
               <RadioButtonContainer
                 val="type"
                 searchBy={this.state.searchBy}
                 handleSearchChange={this.onSearchChange}
                 identifier="typeRadio"
+                tooltip="Types: micro, regional, brewpub, large, planning, bar, contract, proprietor"
               />
-              <RadioButtonContainer
+
+              {/* commenting out the tag radio  button for now, as the API doesn't offer much support for this feature yet. Uncomment and test it yourself to see if more search results appear. If so, feel free to uncomment and commit the code to reintroduce the 'tag' radio button */}
+              {/* <RadioButtonContainer
                 val="tag"
                 searchBy={this.state.searchBy}
                 handleSearchChange={this.onSearchChange}
                 identifier="tagRadio"
-              />
+                tooltip="Example: dog-friendly, patio, food-service, food-truck, tours"
+              /> */}
             </div>
           </div>
         </div>
         <footer className="mx-auto py-3">
           <div className="container text-center">
-            Powered By{' '}
+            Powered By{" "}
             <span className="text-muted">
               <a
                 href="https://www.openbrewerydb.org/"

--- a/src/components/RadioButtonContainer.js
+++ b/src/components/RadioButtonContainer.js
@@ -1,6 +1,13 @@
-import React from 'react';
+import React from "react";
+import ReactTooltip from "react-tooltip";
 
-const RadioButtonContainer = ({val, searchBy, handleSearchChange, identifier }) => {
+const RadioButtonContainer = ({
+  val,
+  searchBy,
+  handleSearchChange,
+  identifier,
+  tooltip
+}) => {
   return (
     <div className="form-check form-check-inline">
       <input
@@ -12,11 +19,16 @@ const RadioButtonContainer = ({val, searchBy, handleSearchChange, identifier }) 
         onChange={handleSearchChange}
         checked={searchBy === val}
       />
-      <label className="form-check-label text-capitalize" htmlFor="cityRadio">
-    {val}
+      <label
+        className="form-check-label text-capitalize"
+        htmlFor="cityRadio"
+        data-tip={tooltip}
+      >
+        {val}
       </label>
+      <ReactTooltip />
     </div>
   );
-}
+};
 
 export default RadioButtonContainer;


### PR DESCRIPTION
Added the react-tooltip dependency. Added tooltips to the radio buttons.
Removed/commented out the 'tag' radio button for now. The API does not offer much support for the tag search options as of now. 
https://github.com/wwayne/react-tooltip