### PR TITLE
Use lowercase filter text (Fix #39)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -61,7 +61,7 @@ class App extends Component {
   filterResults = data =>
     data.filter(
       item =>
-        !item.name.toLowerCase().includes('Brewery In Planning'.toLowerCase())
+        !item.name.toLowerCase().includes('brewery in planning')
     )
 
   whatToDisplay = page => {


### PR DESCRIPTION
Use lowercase filter text `brewery in planning`, instead of calling `.toLowerCase()` on capitalized string.